### PR TITLE
Modify renderer.js

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -55,7 +55,7 @@ function checkConfig(config, md) {
     checkValue(config, _res, 'highlight', function(str, lang) {
         if (lang && hljs.getLanguage(lang)) {
             try {
-                return '<pre class="' + pre_class + '"><code class="' + lang + '">' + hljs.highlight(lang, str, true).value + '</code></pre>';
+                return '<pre class="' + pre_class + '"><code class="' + lang + '">' + hljs.highlight(str, {language: lang, ignoreIllegals: true }).value + '</code></pre>';
             } catch (__) {}
         }
         return '<pre class="' + pre_class + '"><code class="' + lang + '">' + utils.escapeHtml(str) + '</code></pre>';


### PR DESCRIPTION
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
Please use highlight(code, options) instead.
https://github.com/highlightjs/highlight.js/issues/2277